### PR TITLE
simplification of event pulling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ jobs:
             _counter=$(mix credo --only Credo.Check.Readability.SinglePipe | grep -c "Use a function call when a pipeline is only one function long")
             echo "Current Credo.Check.Readability.SinglePipe occurrences:"
             echo $_counter
-            if [ $_counter -gt 44 ]; then
+            if [ $_counter -gt 43 ]; then
               echo "Have you been naughty or nice? Find out if Santa knows."
               exit 1
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -564,7 +564,7 @@ jobs:
       - run: echo 'export PATH=~/.cargo/bin:$PATH' >> $BASH_ENV
       - docker_login
       - run:
-          name: Start geth, postgres, feefeed and pull in blockchain snapshot
+          name: Start geth, feefeed and pull in blockchain snapshot
           command: make start-services
           background: true
       - run: sudo chmod 777 data/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,28 +434,14 @@ jobs:
           working_directory: ~/project/priv/cabbage
           command: mix deps.get
       - run:
+          name: docker services logs
+          working_directory: ~/project/
+          background: true
+          command: docker-compose logs -f  
+      - run:
           name: Test
           working_directory: ~/project/priv/cabbage
           command: mix test
-      - run:
-          name: (Cabbage) Format generated code and check for warnings
-          working_directory: ~/project/priv/cabbage
-          command: |
-            # run format ONLY on formatted code so that it cleans up quoted atoms because
-            # we cannot exclude folders to --warnings-as-errors
-            mix format apps/child_chain_api/lib/child_chain_api/model/*.ex
-            mix format apps/watcher_info_api/lib/watcher_info_api/model/*.ex
-            mix format apps/watcher_security_critical_api/lib/watcher_security_critical_api/model/*.ex
-            MIX_ENV=test mix do compile --warnings-as-errors --ignore-module-conflict --force, test --exclude test
-      - save_cache:
-          key: v2-mix-specs-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
-          paths:
-            - "priv/cabbage/deps"
-      - run:
-          name: (Cabbage) Credo and formatting
-          command: |
-            cd priv/cabbage
-            mix do credo, format --check-formatted --dry-run
 
   test_docker_compose_performance:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ jobs:
             _counter=$(mix credo --only Credo.Check.Readability.SinglePipe | grep -c "Use a function call when a pipeline is only one function long")
             echo "Current Credo.Check.Readability.SinglePipe occurrences:"
             echo $_counter
-            if [ $_counter -gt 60 ]; then
+            if [ $_counter -gt 44 ]; then
               echo "Have you been naughty or nice? Find out if Santa knows."
               exit 1
             fi
@@ -437,7 +437,7 @@ jobs:
           name: docker services logs
           working_directory: ~/project/
           background: true
-          command: docker-compose logs -f  
+          command: docker-compose logs -f
       - run:
           name: Test
           working_directory: ~/project/priv/cabbage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,6 +402,7 @@ jobs:
       image: ubuntu-1604:201903-01
     environment:
       SNAPSHOT: SNAPSHOT_MIX_EXIT_PERIOD_SECONDS_120
+    parallelism: 4
     steps:
       - checkout
       - run:
@@ -441,7 +442,11 @@ jobs:
       - run:
           name: Test
           working_directory: ~/project/priv/cabbage
-          command: mix test
+          command: |
+            grep -r "@moduletag" ./apps/itest/ | awk '{print "--include " $3}' | tr -d ':' > tags.txt
+            echo $(circleci tests split ./tags.txt)
+            circleci tests split ./tags.txt > /tmp/tests-to-run
+            mix test --exclude test $(cat /tmp/tests-to-run)
 
   test_docker_compose_performance:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,7 +546,7 @@ jobs:
             make install
             make generate_api_code
             mix deps.get
-            mix test --only reorg --trace
+            mix test --only deposit --trace
           no_output_timeout: 30m
 
   test_barebone_release:

--- a/Makefile
+++ b/Makefile
@@ -282,10 +282,10 @@ docker-push: docker
 ### Cabbage reorg docker logs
 
 cabbage-reorg-watcher-logs:
-	docker-compose -f docker-compose.yml -f ./priv/cabbage/docker-compose-2-reorg.yml -f ./priv/cabbage/docker-compose-2-specs.yml logs --follow watcher
+	docker-compose -f docker-compose.yml -f docker-compose.reorg.yml -f docker-compose.specs.yml logs --follow watcher
 
 cabbage-reorg-watcher_info-logs:
-	docker-compose -f docker-compose.yml -f ./priv/cabbage/docker-compose-2-reorg.yml -f ./priv/cabbage/docker-compose-2-specs.yml logs --follow watcher_info
+	docker-compose -f docker-compose.yml -f docker-compose.reorg.yml -f docker-compose.specs.yml logs --follow watcher_info
 
 cabbage-reorg-childchain-logs:
 	docker-compose -f docker-compose.yml -f docker-compose.reorg.yml -f docker-compose.specs.yml logs --follow childchain

--- a/Makefile
+++ b/Makefile
@@ -282,10 +282,10 @@ docker-push: docker
 ### Cabbage reorg docker logs
 
 cabbage-reorg-watcher-logs:
-	docker-compose -f docker-compose.yml -f docker-compose.reorg.yml -f docker-compose.specs.yml logs --follow watcher
+	docker-compose -f docker-compose.yml -f ./priv/cabbage/docker-compose-2-reorg.yml -f ./priv/cabbage/docker-compose-2-specs.yml logs --follow watcher
 
 cabbage-reorg-watcher_info-logs:
-	docker-compose -f docker-compose.yml -f docker-compose.reorg.yml -f docker-compose.specs.yml logs --follow watcher_info
+	docker-compose -f docker-compose.yml -f ./priv/cabbage/docker-compose-2-reorg.yml -f ./priv/cabbage/docker-compose-2-specs.yml logs --follow watcher_info
 
 cabbage-reorg-childchain-logs:
 	docker-compose -f docker-compose.yml -f docker-compose.reorg.yml -f docker-compose.specs.yml logs --follow childchain

--- a/apps/omg/lib/omg/ethereum_event_listener.ex
+++ b/apps/omg/lib/omg/ethereum_event_listener.ex
@@ -158,11 +158,11 @@ defmodule OMG.EthereumEventListener do
   end
 
   # see `handle_info/2`, clause for `:sync`
-  @decorate span(service: :ethereum_event_listener, type: :backend, name: "sync_height/2")
+  @decorate span(service: :ethereum_event_listener, type: :backend, name: "sync_height/3")
   defp sync_height(state, callbacks, sync_guide) do
     {events, new_state} =
       state
-      |> Core.get_events_range(sync_guide)
+      |> Core.calc_events_range_set_height(sync_guide)
       |> get_events(callbacks.get_ethereum_events_callback)
 
     db_update = [{:put, new_state.synced_height_update_key, new_state.synced_height}]
@@ -176,7 +176,7 @@ defmodule OMG.EthereumEventListener do
     new_state
   end
 
-  defp get_events({:get_events, {from, to}, state}, get_events_callback) do
+  defp get_events({{from, to}, state}, get_events_callback) do
     {:ok, new_events} = get_events_callback.(from, to)
     {new_events, state}
   end

--- a/apps/omg/lib/omg/ethereum_event_listener.ex
+++ b/apps/omg/lib/omg/ethereum_event_listener.ex
@@ -163,9 +163,9 @@ defmodule OMG.EthereumEventListener do
     {events, new_state} =
       state
       |> Core.get_events_range_for_download(sync_guide)
-      |> get_events(callbacks.get_events_callback)
+      |> get_events(callbacks.get_ethereum_events_callback)
 
-    db_update = [{:put, state.service_name, state.synced_height}]
+    db_update = [{:put, state.synced_height_update_key, state.synced_height}]
     :ok = :telemetry.execute([:process, __MODULE__], %{events: events}, state)
 
     {:ok, db_updates_from_callback} = callbacks.process_events_callback.(events)

--- a/apps/omg/lib/omg/ethereum_event_listener.ex
+++ b/apps/omg/lib/omg/ethereum_event_listener.ex
@@ -165,13 +165,13 @@ defmodule OMG.EthereumEventListener do
       |> Core.get_events_range_for_download(sync_guide)
       |> get_events(callbacks.get_ethereum_events_callback)
 
-    db_update = [{:put, state.synced_height_update_key, state.synced_height}]
-    :ok = :telemetry.execute([:process, __MODULE__], %{events: events}, state)
+    db_update = [{:put, new_state.synced_height_update_key, new_state.synced_height}]
+    :ok = :telemetry.execute([:process, __MODULE__], %{events: events}, new_state)
 
     {:ok, db_updates_from_callback} = callbacks.process_events_callback.(events)
     :ok = publish_events(events)
     :ok = OMG.DB.multi_update(db_update ++ db_updates_from_callback)
-    :ok = RootChainCoordinator.check_in(new_state.synced_height, state.service_name)
+    :ok = RootChainCoordinator.check_in(new_state.synced_height, new_state.service_name)
 
     new_state
   end

--- a/apps/omg/lib/omg/ethereum_event_listener.ex
+++ b/apps/omg/lib/omg/ethereum_event_listener.ex
@@ -146,7 +146,7 @@ defmodule OMG.EthereumEventListener do
 
     case RootChainCoordinator.get_sync_info() do
       :nosync ->
-        :ok = RootChainCoordinator.check_in(Core.get_height_to_check_in(state), state.service_name)
+        :ok = RootChainCoordinator.check_in(state.synced_height, state.service_name)
         {:ok, _} = schedule_get_events(state.ethereum_events_check_interval_ms)
         {:noreply, {state, callbacks}}
 
@@ -160,29 +160,30 @@ defmodule OMG.EthereumEventListener do
   # see `handle_info/2`, clause for `:sync`
   @decorate span(service: :ethereum_event_listener, type: :backend, name: "sync_height/2")
   defp sync_height(state, callbacks, sync_guide) do
-    {:ok, events, db_updates, height_to_check_in, new_state} =
-      Core.get_events_range_for_download(state, sync_guide)
-      |> maybe_update_event_cache(callbacks.get_ethereum_events_callback)
-      |> Core.get_events(sync_guide.sync_height)
+    {events, new_state} =
+      state
+      |> Core.get_events_range_for_download(sync_guide)
+      |> get_events(callbacks.get_events_callback)
 
+    db_update = [{:put, state.service_name, state.synced_height}]
     :ok = :telemetry.execute([:process, __MODULE__], %{events: events}, state)
 
     {:ok, db_updates_from_callback} = callbacks.process_events_callback.(events)
     :ok = publish_events(events)
-    :ok = OMG.DB.multi_update(db_updates ++ db_updates_from_callback)
-    :ok = RootChainCoordinator.check_in(height_to_check_in, state.service_name)
+    :ok = OMG.DB.multi_update(db_update ++ db_updates_from_callback)
+    :ok = RootChainCoordinator.check_in(new_state.synced_height, state.service_name)
 
     new_state
   end
 
-  @decorate span(service: :ethereum_event_listener, type: :backend, name: "maybe_update_event_cache/2")
-  defp maybe_update_event_cache({:get_events, {from, to}, %Core{} = state}, get_ethereum_events_callback) do
-    {:ok, new_events} = get_ethereum_events_callback.(from, to)
-    Core.add_new_events(state, new_events)
+  defp get_events({:get_events, {from, to}, state}, get_events_callback) do
+    {:ok, new_events} = get_events_callback.(from, to)
+    {new_events, state}
   end
 
-  @decorate span(service: :ethereum_event_listener, type: :backend, name: "maybe_update_event_cache/2")
-  defp maybe_update_event_cache({:dont_fetch_events, %Core{} = state}, _callback), do: state
+  defp get_events({:dont_fetch_events, state}, _callback) do
+    {[], state}
+  end
 
   defp schedule_get_events(ethereum_events_check_interval_ms) do
     :timer.send_after(ethereum_events_check_interval_ms, self(), :sync)

--- a/apps/omg/lib/omg/ethereum_event_listener.ex
+++ b/apps/omg/lib/omg/ethereum_event_listener.ex
@@ -162,7 +162,7 @@ defmodule OMG.EthereumEventListener do
   defp sync_height(state, callbacks, sync_guide) do
     {events, new_state} =
       state
-      |> Core.get_events_range_for_download(sync_guide)
+      |> Core.get_events_range(sync_guide)
       |> get_events(callbacks.get_ethereum_events_callback)
 
     db_update = [{:put, new_state.synced_height_update_key, new_state.synced_height}]

--- a/apps/omg/lib/omg/ethereum_event_listener/core.ex
+++ b/apps/omg/lib/omg/ethereum_event_listener/core.ex
@@ -82,8 +82,8 @@ defmodule OMG.EthereumEventListener.Core do
         # if sync_guide.sync_height has applied margin (reorg protection)
         # the only thing we need to be aware of is that we don't go pass that!
         # but we want to move as fast as possible so we try to fetch as much as we can (request_max_size)
-
-        next_upper_bound = min(sync_guide.sync_height, state.synced_height + 1 + state.request_max_size)
+        first_not_visited = state.synced_height + 1
+        next_upper_bound = min(sync_guide.sync_height, first_not_visited + state.request_max_size)
 
         {:get_events, {state.synced_height + 1, next_upper_bound}, %{state | synced_height: next_upper_bound}}
     end

--- a/apps/omg/lib/omg/ethereum_event_listener/core.ex
+++ b/apps/omg/lib/omg/ethereum_event_listener/core.ex
@@ -28,7 +28,8 @@ defmodule OMG.EthereumEventListener.Core do
 
   use Spandex.Decorators
 
-  # synced_height is what's being exchanged with `RootChainCoordinator` - the point in root chain until where it processed
+  # synced_height is what's being exchanged with `RootChainCoordinator`. 
+  # The point in root chain until where it processed
   defstruct synced_height_update_key: nil,
             service_name: nil,
             synced_height: 0,
@@ -82,9 +83,10 @@ defmodule OMG.EthereumEventListener.Core do
         # both root_chain_height and sync_height are assumed to have any required finality margins applied by caller
         root_chain_height = sync_guide.root_chain_height
         request_max_size = state.request_max_size
-
-        next_upper_bound =
-          max(min(root_chain_height, sync_guide.sync_height + request_max_size), sync_guide.sync_height)
+        # root_chain_height is ethereums current height, we can't get pass that!
+        # so we find the min between root chain height and
+        # the current sync hight (state.synced_height) + what the max is (default is 1000)
+        next_upper_bound = max(min(root_chain_height, state.synced_height + request_max_size), sync_guide.sync_height)
 
         {:get_events, {state.synced_height + 1, next_upper_bound}, %{state | synced_height: next_upper_bound}}
     end

--- a/apps/omg/lib/omg/ethereum_event_listener/core.ex
+++ b/apps/omg/lib/omg/ethereum_event_listener/core.ex
@@ -28,7 +28,7 @@ defmodule OMG.EthereumEventListener.Core do
 
   use Spandex.Decorators
 
-  # synced_height is what's being exchanged with `RootChainCoordinator`. 
+  # synced_height is what's being exchanged with `RootChainCoordinator`.
   # The point in root chain until where it processed
   defstruct synced_height_update_key: nil,
             service_name: nil,

--- a/apps/omg/lib/omg/ethereum_event_listener/core.ex
+++ b/apps/omg/lib/omg/ethereum_event_listener/core.ex
@@ -28,29 +28,21 @@ defmodule OMG.EthereumEventListener.Core do
 
   use Spandex.Decorators
 
+  # synced_height is what's being exchanged with `RootChainCoordinator` - the point in root chain until where it processed
   defstruct synced_height_update_key: nil,
             service_name: nil,
-            # what's being exchanged with `RootChainCoordinator` - the point in root chain until where it processed
             synced_height: 0,
             ethereum_events_check_interval_ms: nil,
-            cached: %{
-              data: [],
-              request_max_size: 1000,
-              # until which height the events have been pulled and cached
-              events_upper_bound: 0
-            }
+            request_max_size: 1000
 
   @type event :: %{eth_height: non_neg_integer()}
 
   @type t() :: %__MODULE__{
           synced_height_update_key: atom(),
           service_name: atom(),
-          cached: %{
-            data: list(event),
-            request_max_size: pos_integer(),
-            events_upper_bound: non_neg_integer()
-          },
-          ethereum_events_check_interval_ms: non_neg_integer()
+          synced_height: integer(),
+          ethereum_events_check_interval_ms: non_neg_integer(),
+          request_max_size: pos_integer()
         }
 
   @doc """
@@ -70,89 +62,31 @@ defmodule OMG.EthereumEventListener.Core do
       synced_height_update_key: update_key,
       synced_height: last_synced_ethereum_height,
       service_name: service_name,
-      cached: %{
-        data: [],
-        request_max_size: request_max_size,
-        events_upper_bound: last_synced_ethereum_height
-      },
+      request_max_size: request_max_size,
       ethereum_events_check_interval_ms: ethereum_events_check_interval_ms
     }
 
-    {initial_state, get_height_to_check_in(initial_state)}
+    {initial_state, last_synced_ethereum_height}
   end
 
-  @doc """
-  Provides a uniform way to get the height to check in.
-
-  Every call to RootChainCoordinator.check_in should use value taken from this, after all mutations to the state
-  """
-  @spec get_height_to_check_in(t()) :: non_neg_integer()
-  def get_height_to_check_in(%__MODULE__{synced_height: synced_height}), do: synced_height
-
-  @doc """
-  Returns range Ethereum height to download
-  """
   @decorate span(service: :ethereum_event_listener, type: :backend, name: "get_events_range_for_download/2")
   @spec get_events_range_for_download(t(), SyncGuide.t()) ::
           {:dont_fetch_events, t()} | {:get_events, {non_neg_integer, non_neg_integer}, t()}
-  def get_events_range_for_download(%__MODULE__{cached: %{events_upper_bound: upper}} = state, %SyncGuide{
-        sync_height: sync_height
-      })
-      when sync_height <= upper,
-      do: {:dont_fetch_events, state}
+  def get_events_range_for_download(state, sync_guide) do
+    case sync_guide.sync_height <= state.synced_height do
+      true ->
+        {:dont_fetch_events, state}
 
-  @decorate span(service: :ethereum_event_listener, type: :backend, name: "get_events_range_for_download/2")
-  def get_events_range_for_download(
-        %__MODULE__{
-          cached: %{request_max_size: request_max_size, events_upper_bound: old_upper_bound} = cached_data
-        } = state,
-        %SyncGuide{root_chain_height: root_chain_height, sync_height: sync_height}
-      ) do
-    # grab as much as allowed, but not higher than current root_chain_height and at least as much as needed to sync
-    # NOTE: both root_chain_height and sync_height are assumed to have any required finality margins applied by caller
-    next_upper_bound =
-      min(root_chain_height, old_upper_bound + request_max_size)
-      |> max(sync_height)
+      _ ->
+        # grab as much as allowed, but not higher than current root_chain_height and at least as much as needed to sync
+        # both root_chain_height and sync_height are assumed to have any required finality margins applied by caller
+        root_chain_height = sync_guide.root_chain_height
+        request_max_size = state.request_max_size
 
-    new_state = %__MODULE__{
-      state
-      | cached: %{cached_data | events_upper_bound: next_upper_bound}
-    }
+        next_upper_bound =
+          max(min(root_chain_height, sync_guide.sync_height + request_max_size), sync_guide.sync_height)
 
-    {:get_events, {old_upper_bound + 1, next_upper_bound}, new_state}
-  end
-
-  @doc """
-  Stores the freshly fetched ethereum events into a memory-cache
-  """
-  @decorate span(service: :ethereum_event_listener, type: :backend, name: "add_new_events/2")
-  @spec add_new_events(t(), list(event)) :: t()
-  def add_new_events(
-        %__MODULE__{cached: %{data: data} = cached_data} = state,
-        new_events
-      ) do
-    %__MODULE__{state | cached: %{cached_data | data: data ++ new_events}}
-  end
-
-  @doc """
-  Pop some ethereum events stored in the memory-cache, up to a certain height
-  """
-  @decorate span(service: :ethereum_event_listener, type: :backend, name: "get_events/2")
-  @spec get_events(t(), non_neg_integer) :: {:ok, list(event), list(), non_neg_integer, t()}
-  def get_events(
-        %__MODULE__{synced_height_update_key: update_key, cached: %{data: data}} = state,
-        new_sync_height
-      ) do
-    {events, new_data} = Enum.split_while(data, fn %{eth_height: height} -> height <= new_sync_height end)
-
-    new_state =
-      state
-      |> Map.update!(:synced_height, &max(&1, new_sync_height))
-      |> Map.update!(:cached, &%{&1 | data: new_data})
-      |> struct!()
-
-    height_to_check_in = get_height_to_check_in(new_state)
-    db_update = [{:put, update_key, height_to_check_in}]
-    {:ok, events, db_update, height_to_check_in, new_state}
+        {:get_events, {state.synced_height + 1, next_upper_bound}, %{state | synced_height: next_upper_bound}}
+    end
   end
 end

--- a/apps/omg/lib/omg/state.ex
+++ b/apps/omg/lib/omg/state.ex
@@ -71,19 +71,6 @@ defmodule OMG.State do
   end
 
   @doc """
-  Intended for the `OMG.Watcher`. "Closes" a block, acknowledging that all transactions have been executed, and the next
-  `exec/2` will belong to the next block.
-
-  Depends on the caller to do persistence.
-
-  Synchronous
-  """
-  @spec close_block() :: {:ok, list(Core.db_update())}
-  def close_block() do
-    GenServer.call(__MODULE__, :close_block, @timeout)
-  end
-
-  @doc """
   Intended for the `OMG.ChildChain`. Forms a new block and persist it. Broadcasts the block to the internal event bus
   to be used in other processes.
 
@@ -233,22 +220,6 @@ defmodule OMG.State do
   """
   def handle_call(:get_status, _from, state) do
     {:reply, Core.get_status(state), state}
-  end
-
-  @doc """
-  see `close_block/0`
-
-  Works exactly like `handle_cast(:form_block)` but:
-   - is synchronous
-   - relies on the caller to handle persistence, instead of handling itself
-
-  Someday, one might want to skip some of computations done (like calculating the root hash, which is scrapped)
-  """
-  def handle_call(:close_block, _from, state) do
-    {:ok, {block, db_updates}, new_state} = Core.form_block(state)
-
-    :ok = publish_block_to_event_bus(block)
-    {:reply, {:ok, db_updates}, new_state}
   end
 
   @doc """

--- a/apps/omg/test/omg/ethereum_event_listener/core_test.exs
+++ b/apps/omg/test/omg/ethereum_event_listener/core_test.exs
@@ -38,13 +38,15 @@ defmodule OMG.EthereumEventListener.CoreTest do
     |> assert_range({1, 10})
   end
 
-  test "max request size is ignored if above allowed sync_height" do
+  test "event range is capped at the SyncGuide sync_height" do
+    # if request_max_size would taken into account it would
+    # push the event range above the treshold and would remove the reorg protection
     create_state(0, request_max_size: 2)
     |> Core.get_events_range(%SyncGuide{sync_height: 1, root_chain_height: 10})
     |> assert_range({1, 1})
   end
 
-  test "max request size ignored if caller is insisting to get a lot of events" do
+  test "get events range is capped at request_max_size and the events range returned is less then SyncGuide sync_height" do
     create_state(0, request_max_size: 2)
     |> Core.get_events_range(%SyncGuide{sync_height: 4, root_chain_height: 10})
     |> assert_range({1, 3})

--- a/apps/omg/test/omg/ethereum_event_listener/core_test.exs
+++ b/apps/omg/test/omg/ethereum_event_listener/core_test.exs
@@ -24,166 +24,122 @@ defmodule OMG.EthereumEventListener.CoreTest do
   @service_name :name
   @request_max_size 5
 
-  # test "asks until root chain height provided" do
-  #   create_state(0, request_max_size: 100)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
-  #   |> assert_range({1, 10})
-  # end
+  test "asks until root chain height provided" do
+    create_state(0, request_max_size: 100)
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
+    |> assert_range({1, 10})
+  end
 
-  # test "max request size respected" do
-  #   create_state(0, request_max_size: 2)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
-  #   |> assert_range({1, 2})
-  # end
+  test "max request size respected" do
+    create_state(0, request_max_size: 2)
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
+    |> assert_range({1, 2})
+  end
 
-  # test "max request size ignored if caller is insiting to get a lot of events" do
-  #   # this might be counterintuitive, but to we require that the requested sync_height is never left unhandled
-  #   create_state(0, request_max_size: 2)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 10})
-  #   |> assert_range({1, 4})
-  # end
+  test "max request size ignored if caller is insiting to get a lot of events" do
+    # this might be counterintuitive, but to we require that the requested sync_height is never left unhandled
+    create_state(0, request_max_size: 2)
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 10})
+    |> assert_range({1, 4})
+  end
 
-  # test "works well close to zero" do
-  #   create_state(0)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
-  #   |> assert_range({1, 5})
-  #   |> Core.add_new_events([event(1), event(3), event(4), event(5)])
-  #   |> Core.get_events(0)
-  #   |> assert_events(events: [], check_in_and_db: 0)
-  #   |> Core.get_events(1)
-  #   |> assert_events(events: [event(1)], check_in_and_db: 1)
-  #   |> Core.get_events(2)
-  #   |> assert_events(events: [], check_in_and_db: 2)
-  #   |> Core.get_events(3)
-  #   |> assert_events(events: [event(3)], check_in_and_db: 3)
-  # end
+  test "works well close to zero" do
+    0
+    |> create_state()
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
+    |> assert_range({1, 5})
+  end
 
-  # test "always returns correct height to check in" do
-  #   state =
-  #     create_state(0)
-  #     |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
-  #     |> assert_range({1, 5})
-  #     |> Core.get_events(0)
-  #     |> assert_events(events: [], check_in_and_db: 0)
+  test "always returns correct height to check in" do
+    state =
+      0
+      |> create_state()
+      |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
+      |> assert_range({1, 5})
 
-  #   assert 0 == Core.get_height_to_check_in(state)
+    assert state.synced_height == 5
+  end
 
-  #   state =
-  #     state
-  #     |> Core.get_events(1)
-  #     |> assert_events(events: [], check_in_and_db: 1)
+  test "produces next ethereum height range to get events from" do
+    0
+    |> create_state()
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
+    |> assert_range({1, 5})
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
+    |> assert_range(:dont_fetch_events)
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 10})
+    |> assert_range({6, 10})
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 10})
+    |> assert_range(:dont_fetch_events)
+  end
 
-  #   assert 1 == Core.get_height_to_check_in(state)
-  # end
+  test "if synced requested higher than root chain height" do
+    # doesn't make too much sense, but still should work well
+    0
+    |> create_state()
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 5})
+    |> assert_range({1, 5})
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 5})
+    |> assert_range({6, 7})
+  end
 
-  # test "produces next ethereum height range to get events from" do
-  #   create_state(0)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
-  #   |> assert_range({1, 5})
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
-  #   |> assert_range(:dont_fetch_events)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 10})
-  #   |> assert_range({6, 10})
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 10})
-  #   |> assert_range(:dont_fetch_events)
-  # end
+  test "will be eager to get more events, even if none are pulled at first. All will be returned" do
+    0
+    |> create_state()
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 2, root_chain_height: 2})
+    |> assert_range({1, 2})
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 4})
+    |> assert_range({3, 4})
+  end
 
-  # test "if synced requested higher than root chain height" do
-  #   # doesn't make too much sense, but still should work well
-  #   create_state(0)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 5})
-  #   |> assert_range({1, 5})
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 5})
-  #   |> assert_range({6, 7})
-  # end
+  test "restart allows to continue with proper bounds" do
+    1
+    |> create_state()
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 10})
+    |> assert_range({2, 6})
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 10})
+    |> assert_range(:dont_fetch_events)
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
+    |> assert_range(:dont_fetch_events)
 
-  # test "will be eager to get more events, even if none are pulled at first. All will be returned" do
-  #   create_state(0)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 2, root_chain_height: 2})
-  #   |> assert_range({1, 2})
-  #   |> Core.add_new_events([event(1), event(2)])
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 4})
-  #   |> assert_range({3, 4})
-  #   |> Core.add_new_events([event(3), event(4)])
-  #   |> Core.get_events(4)
-  #   |> assert_events(events: [event(1), event(2), event(3), event(4)], check_in_and_db: 4)
-  # end
+    3
+    |> create_state()
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 3, root_chain_height: 10})
+    |> assert_range(:dont_fetch_events)
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
+    |> assert_range({4, 8})
 
-  # test "restart allows to continue with proper bounds" do
-  #   create_state(1)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 10})
-  #   |> assert_range({2, 6})
-  #   |> Core.add_new_events([event(2), event(4), event(5), event(6)])
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 10})
-  #   |> assert_range(:dont_fetch_events)
-  #   |> Core.get_events(4)
-  #   |> assert_events(events: [event(2), event(4)], check_in_and_db: 4)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
-  #   |> assert_range(:dont_fetch_events)
-  #   |> Core.get_events(5)
-  #   |> assert_events(events: [event(5)], check_in_and_db: 5)
+    3
+    |> create_state()
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 10})
+    |> assert_range({4, 8})
+  end
 
-  #   create_state(3)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 3, root_chain_height: 10})
-  #   |> assert_range(:dont_fetch_events)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
-  #   |> assert_range({4, 8})
-  #   |> Core.add_new_events([event(4), event(5), event(7)])
-  #   |> Core.get_events(3)
-  #   |> assert_events(events: [], check_in_and_db: 3)
-  #   |> Core.get_events(5)
-  #   |> assert_events(events: [event(4), event(5)], check_in_and_db: 5)
+  test "can get multiple events from one height" do
+    5
+    |> create_state()
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 6, root_chain_height: 10})
+    |> assert_range({6, 10})
+  end
 
-  #   create_state(3)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 10})
-  #   |> assert_range({4, 8})
-  #   |> Core.add_new_events([event(4), event(5), event(7)])
-  #   |> Core.get_events(7)
-  #   |> assert_events(events: [event(4), event(5), event(7)], check_in_and_db: 7)
-  # end
+  test "can get an empty events list when events too fresh" do
+    4
+    |> create_state()
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 6, root_chain_height: 10})
+    |> assert_range({5, 9})
+  end
 
-  # test "can get multiple events from one height" do
-  #   create_state(5)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 6, root_chain_height: 10})
-  #   |> assert_range({6, 10})
-  #   |> Core.add_new_events([event(6), event(6), event(7)])
-  #   |> Core.get_events(6)
-  #   |> assert_events(events: [event(6), event(6)], check_in_and_db: 6)
-  # end
+  test "persists/checks in eth_height without margins substracted, and never goes negative" do
+    create_state(0, request_max_size: 10)
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 6, root_chain_height: 10})
+    |> assert_range({1, 10})
+  end
 
-  # test "can get an empty events list when events too fresh" do
-  #   create_state(4)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 6, root_chain_height: 10})
-  #   |> assert_range({5, 9})
-  #   |> Core.add_new_events([event(5), event(5), event(6)])
-  #   |> Core.get_events(4)
-  #   |> assert_events(events: [], check_in_and_db: 4)
-  # end
-
-  # test "doesn't fail when getting events from empty" do
-  #   create_state(1)
-  #   |> Core.get_events(5)
-  #   |> assert_events(events: [], check_in_and_db: 5)
-  # end
-
-  # test "persists/checks in eth_height without margins substracted, and never goes negative" do
-  #   state =
-  #     create_state(0, request_max_size: 10)
-  #     |> Core.get_events_range_for_download(%SyncGuide{sync_height: 6, root_chain_height: 10})
-  #     |> assert_range({1, 10})
-  #     |> Core.add_new_events([event(6), event(7), event(8), event(9)])
-
-  #   for i <- 1..9, do: state |> Core.get_events(i) |> assert_events(check_in_and_db: i)
-  # end
-
-  # test "tolerates being asked to sync on height already synced" do
-  #   create_state(5)
-  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
-  #   |> assert_range(:dont_fetch_events)
-  #   |> Core.add_new_events([])
-  #   |> Core.get_events(1)
-  #   |> assert_events(events: [], check_in_and_db: 5)
-  # end
+  test "tolerates being asked to sync on height already synced" do
+    create_state(5)
+    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
+    |> assert_range(:dont_fetch_events)
+  end
 
   defp create_state(height, opts \\ []) do
     request_max_size = Keyword.get(opts, :request_max_size, @request_max_size)
@@ -200,8 +156,6 @@ defmodule OMG.EthereumEventListener.CoreTest do
     state
   end
 
-  defp event(height), do: %{eth_height: height}
-
   defp assert_range({:get_events, range, state}, expect) do
     assert range == expect
     state
@@ -210,14 +164,5 @@ defmodule OMG.EthereumEventListener.CoreTest do
   defp assert_range({:dont_fetch_events, state}, expect) do
     assert :dont_fetch_events == expect
     state
-  end
-
-  defp assert_events(response, opts) do
-    expected_check_in_and_db = Keyword.get(opts, :check_in_and_db)
-    expected_events = Keyword.get(opts, :events)
-    assert {:ok, events, [{:put, @db_key, check_in_and_db}], check_in_and_db, new_state} = response
-    if expected_events, do: assert(expected_events == events)
-    if expected_check_in_and_db, do: assert(expected_check_in_and_db == check_in_and_db)
-    new_state
   end
 end

--- a/apps/omg/test/omg/ethereum_event_listener/core_test.exs
+++ b/apps/omg/test/omg/ethereum_event_listener/core_test.exs
@@ -53,22 +53,15 @@ defmodule OMG.EthereumEventListener.CoreTest do
   test "works well close to zero" do
     0
     |> create_state()
-    # |> IO.inspect
     |> Core.get_events_range(%SyncGuide{sync_height: 1, root_chain_height: 10})
     |> assert_range({1, 1})
-    # |> IO.inspect
     |> Core.get_events_range(%SyncGuide{sync_height: 8, root_chain_height: 10})
     |> assert_range({2, 7})
-
-    # |> IO.inspect
 
     0
     |> create_state()
     |> Core.get_events_range(%SyncGuide{sync_height: 9, root_chain_height: 10})
     |> assert_range({1, 6})
-
-    # |> Core.get_events_range(%SyncGuide{sync_height: 9, root_chain_height: 10})
-    # |> assert_range({2, 7})
   end
 
   test "always returns correct height to check in" do

--- a/apps/omg/test/omg/ethereum_event_listener/core_test.exs
+++ b/apps/omg/test/omg/ethereum_event_listener/core_test.exs
@@ -24,166 +24,166 @@ defmodule OMG.EthereumEventListener.CoreTest do
   @service_name :name
   @request_max_size 5
 
-  test "asks until root chain height provided" do
-    create_state(0, request_max_size: 100)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
-    |> assert_range({1, 10})
-  end
+  # test "asks until root chain height provided" do
+  #   create_state(0, request_max_size: 100)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
+  #   |> assert_range({1, 10})
+  # end
 
-  test "max request size respected" do
-    create_state(0, request_max_size: 2)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
-    |> assert_range({1, 2})
-  end
+  # test "max request size respected" do
+  #   create_state(0, request_max_size: 2)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
+  #   |> assert_range({1, 2})
+  # end
 
-  test "max request size ignored if caller is insiting to get a lot of events" do
-    # this might be counterintuitive, but to we require that the requested sync_height is never left unhandled
-    create_state(0, request_max_size: 2)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 10})
-    |> assert_range({1, 4})
-  end
+  # test "max request size ignored if caller is insiting to get a lot of events" do
+  #   # this might be counterintuitive, but to we require that the requested sync_height is never left unhandled
+  #   create_state(0, request_max_size: 2)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 10})
+  #   |> assert_range({1, 4})
+  # end
 
-  test "works well close to zero" do
-    create_state(0)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
-    |> assert_range({1, 5})
-    |> Core.add_new_events([event(1), event(3), event(4), event(5)])
-    |> Core.get_events(0)
-    |> assert_events(events: [], check_in_and_db: 0)
-    |> Core.get_events(1)
-    |> assert_events(events: [event(1)], check_in_and_db: 1)
-    |> Core.get_events(2)
-    |> assert_events(events: [], check_in_and_db: 2)
-    |> Core.get_events(3)
-    |> assert_events(events: [event(3)], check_in_and_db: 3)
-  end
+  # test "works well close to zero" do
+  #   create_state(0)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
+  #   |> assert_range({1, 5})
+  #   |> Core.add_new_events([event(1), event(3), event(4), event(5)])
+  #   |> Core.get_events(0)
+  #   |> assert_events(events: [], check_in_and_db: 0)
+  #   |> Core.get_events(1)
+  #   |> assert_events(events: [event(1)], check_in_and_db: 1)
+  #   |> Core.get_events(2)
+  #   |> assert_events(events: [], check_in_and_db: 2)
+  #   |> Core.get_events(3)
+  #   |> assert_events(events: [event(3)], check_in_and_db: 3)
+  # end
 
-  test "always returns correct height to check in" do
-    state =
-      create_state(0)
-      |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
-      |> assert_range({1, 5})
-      |> Core.get_events(0)
-      |> assert_events(events: [], check_in_and_db: 0)
+  # test "always returns correct height to check in" do
+  #   state =
+  #     create_state(0)
+  #     |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
+  #     |> assert_range({1, 5})
+  #     |> Core.get_events(0)
+  #     |> assert_events(events: [], check_in_and_db: 0)
 
-    assert 0 == Core.get_height_to_check_in(state)
+  #   assert 0 == Core.get_height_to_check_in(state)
 
-    state =
-      state
-      |> Core.get_events(1)
-      |> assert_events(events: [], check_in_and_db: 1)
+  #   state =
+  #     state
+  #     |> Core.get_events(1)
+  #     |> assert_events(events: [], check_in_and_db: 1)
 
-    assert 1 == Core.get_height_to_check_in(state)
-  end
+  #   assert 1 == Core.get_height_to_check_in(state)
+  # end
 
-  test "produces next ethereum height range to get events from" do
-    create_state(0)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
-    |> assert_range({1, 5})
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
-    |> assert_range(:dont_fetch_events)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 10})
-    |> assert_range({6, 10})
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 10})
-    |> assert_range(:dont_fetch_events)
-  end
+  # test "produces next ethereum height range to get events from" do
+  #   create_state(0)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
+  #   |> assert_range({1, 5})
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
+  #   |> assert_range(:dont_fetch_events)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 10})
+  #   |> assert_range({6, 10})
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 10})
+  #   |> assert_range(:dont_fetch_events)
+  # end
 
-  test "if synced requested higher than root chain height" do
-    # doesn't make too much sense, but still should work well
-    create_state(0)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 5})
-    |> assert_range({1, 5})
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 5})
-    |> assert_range({6, 7})
-  end
+  # test "if synced requested higher than root chain height" do
+  #   # doesn't make too much sense, but still should work well
+  #   create_state(0)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 5})
+  #   |> assert_range({1, 5})
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 5})
+  #   |> assert_range({6, 7})
+  # end
 
-  test "will be eager to get more events, even if none are pulled at first. All will be returned" do
-    create_state(0)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 2, root_chain_height: 2})
-    |> assert_range({1, 2})
-    |> Core.add_new_events([event(1), event(2)])
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 4})
-    |> assert_range({3, 4})
-    |> Core.add_new_events([event(3), event(4)])
-    |> Core.get_events(4)
-    |> assert_events(events: [event(1), event(2), event(3), event(4)], check_in_and_db: 4)
-  end
+  # test "will be eager to get more events, even if none are pulled at first. All will be returned" do
+  #   create_state(0)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 2, root_chain_height: 2})
+  #   |> assert_range({1, 2})
+  #   |> Core.add_new_events([event(1), event(2)])
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 4})
+  #   |> assert_range({3, 4})
+  #   |> Core.add_new_events([event(3), event(4)])
+  #   |> Core.get_events(4)
+  #   |> assert_events(events: [event(1), event(2), event(3), event(4)], check_in_and_db: 4)
+  # end
 
-  test "restart allows to continue with proper bounds" do
-    create_state(1)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 10})
-    |> assert_range({2, 6})
-    |> Core.add_new_events([event(2), event(4), event(5), event(6)])
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 10})
-    |> assert_range(:dont_fetch_events)
-    |> Core.get_events(4)
-    |> assert_events(events: [event(2), event(4)], check_in_and_db: 4)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
-    |> assert_range(:dont_fetch_events)
-    |> Core.get_events(5)
-    |> assert_events(events: [event(5)], check_in_and_db: 5)
+  # test "restart allows to continue with proper bounds" do
+  #   create_state(1)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 10})
+  #   |> assert_range({2, 6})
+  #   |> Core.add_new_events([event(2), event(4), event(5), event(6)])
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 4, root_chain_height: 10})
+  #   |> assert_range(:dont_fetch_events)
+  #   |> Core.get_events(4)
+  #   |> assert_events(events: [event(2), event(4)], check_in_and_db: 4)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
+  #   |> assert_range(:dont_fetch_events)
+  #   |> Core.get_events(5)
+  #   |> assert_events(events: [event(5)], check_in_and_db: 5)
 
-    create_state(3)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 3, root_chain_height: 10})
-    |> assert_range(:dont_fetch_events)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
-    |> assert_range({4, 8})
-    |> Core.add_new_events([event(4), event(5), event(7)])
-    |> Core.get_events(3)
-    |> assert_events(events: [], check_in_and_db: 3)
-    |> Core.get_events(5)
-    |> assert_events(events: [event(4), event(5)], check_in_and_db: 5)
+  #   create_state(3)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 3, root_chain_height: 10})
+  #   |> assert_range(:dont_fetch_events)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 5, root_chain_height: 10})
+  #   |> assert_range({4, 8})
+  #   |> Core.add_new_events([event(4), event(5), event(7)])
+  #   |> Core.get_events(3)
+  #   |> assert_events(events: [], check_in_and_db: 3)
+  #   |> Core.get_events(5)
+  #   |> assert_events(events: [event(4), event(5)], check_in_and_db: 5)
 
-    create_state(3)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 10})
-    |> assert_range({4, 8})
-    |> Core.add_new_events([event(4), event(5), event(7)])
-    |> Core.get_events(7)
-    |> assert_events(events: [event(4), event(5), event(7)], check_in_and_db: 7)
-  end
+  #   create_state(3)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 7, root_chain_height: 10})
+  #   |> assert_range({4, 8})
+  #   |> Core.add_new_events([event(4), event(5), event(7)])
+  #   |> Core.get_events(7)
+  #   |> assert_events(events: [event(4), event(5), event(7)], check_in_and_db: 7)
+  # end
 
-  test "can get multiple events from one height" do
-    create_state(5)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 6, root_chain_height: 10})
-    |> assert_range({6, 10})
-    |> Core.add_new_events([event(6), event(6), event(7)])
-    |> Core.get_events(6)
-    |> assert_events(events: [event(6), event(6)], check_in_and_db: 6)
-  end
+  # test "can get multiple events from one height" do
+  #   create_state(5)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 6, root_chain_height: 10})
+  #   |> assert_range({6, 10})
+  #   |> Core.add_new_events([event(6), event(6), event(7)])
+  #   |> Core.get_events(6)
+  #   |> assert_events(events: [event(6), event(6)], check_in_and_db: 6)
+  # end
 
-  test "can get an empty events list when events too fresh" do
-    create_state(4)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 6, root_chain_height: 10})
-    |> assert_range({5, 9})
-    |> Core.add_new_events([event(5), event(5), event(6)])
-    |> Core.get_events(4)
-    |> assert_events(events: [], check_in_and_db: 4)
-  end
+  # test "can get an empty events list when events too fresh" do
+  #   create_state(4)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 6, root_chain_height: 10})
+  #   |> assert_range({5, 9})
+  #   |> Core.add_new_events([event(5), event(5), event(6)])
+  #   |> Core.get_events(4)
+  #   |> assert_events(events: [], check_in_and_db: 4)
+  # end
 
-  test "doesn't fail when getting events from empty" do
-    create_state(1)
-    |> Core.get_events(5)
-    |> assert_events(events: [], check_in_and_db: 5)
-  end
+  # test "doesn't fail when getting events from empty" do
+  #   create_state(1)
+  #   |> Core.get_events(5)
+  #   |> assert_events(events: [], check_in_and_db: 5)
+  # end
 
-  test "persists/checks in eth_height without margins substracted, and never goes negative" do
-    state =
-      create_state(0, request_max_size: 10)
-      |> Core.get_events_range_for_download(%SyncGuide{sync_height: 6, root_chain_height: 10})
-      |> assert_range({1, 10})
-      |> Core.add_new_events([event(6), event(7), event(8), event(9)])
+  # test "persists/checks in eth_height without margins substracted, and never goes negative" do
+  #   state =
+  #     create_state(0, request_max_size: 10)
+  #     |> Core.get_events_range_for_download(%SyncGuide{sync_height: 6, root_chain_height: 10})
+  #     |> assert_range({1, 10})
+  #     |> Core.add_new_events([event(6), event(7), event(8), event(9)])
 
-    for i <- 1..9, do: state |> Core.get_events(i) |> assert_events(check_in_and_db: i)
-  end
+  #   for i <- 1..9, do: state |> Core.get_events(i) |> assert_events(check_in_and_db: i)
+  # end
 
-  test "tolerates being asked to sync on height already synced" do
-    create_state(5)
-    |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
-    |> assert_range(:dont_fetch_events)
-    |> Core.add_new_events([])
-    |> Core.get_events(1)
-    |> assert_events(events: [], check_in_and_db: 5)
-  end
+  # test "tolerates being asked to sync on height already synced" do
+  #   create_state(5)
+  #   |> Core.get_events_range_for_download(%SyncGuide{sync_height: 1, root_chain_height: 10})
+  #   |> assert_range(:dont_fetch_events)
+  #   |> Core.add_new_events([])
+  #   |> Core.get_events(1)
+  #   |> assert_events(events: [], check_in_and_db: 5)
+  # end
 
   defp create_state(height, opts \\ []) do
     request_max_size = Keyword.get(opts, :request_max_size, @request_max_size)

--- a/apps/omg/test/omg/state/transaction/recovered_test.exs
+++ b/apps/omg/test/omg/state/transaction/recovered_test.exs
@@ -592,7 +592,8 @@ defmodule OMG.State.Transaction.RecoveredTest do
     alice = TestHelper.generate_entity()
 
     good_tx_rlp_items =
-      TestHelper.create_encoded([{1000, 0, 0, alice}, {1000, 0, 1, alice}], [{alice, @eth, 10}])
+      [{1000, 0, 0, alice}, {1000, 0, 1, alice}]
+      |> TestHelper.create_encoded([{alice, @eth, 10}])
       |> ExRLP.decode()
 
     # sanity check just in case

--- a/apps/omg/test/omg/state/utxo_set_test.exs
+++ b/apps/omg/test/omg/state/utxo_set_test.exs
@@ -157,11 +157,11 @@ defmodule OMG.State.UtxoSetTest do
 
   describe "filter_owned_by/2" do
     test "will find Bob's utxos", %{bob: bob, utxo_set: utxo_set} do
-      assert [_, _] = UtxoSet.filter_owned_by(utxo_set, bob.addr) |> Enum.to_list()
+      assert [_, _] = Enum.to_list(UtxoSet.filter_owned_by(utxo_set, bob.addr))
     end
 
     test "will NOT find Alice's utxos, b/c she doesn't have any", %{alice: alice, utxo_set: utxo_set} do
-      assert [] = UtxoSet.filter_owned_by(utxo_set, alice.addr) |> Enum.to_list()
+      assert [] = Enum.to_list(UtxoSet.filter_owned_by(utxo_set, alice.addr))
     end
   end
 

--- a/apps/omg/test/omg/state_test.exs
+++ b/apps/omg/test/omg/state_test.exs
@@ -62,23 +62,4 @@ defmodule OMG.StateTest do
 
     :ok
   end
-
-  @tag fixtures: [:alice, :standalone_state_server]
-  test "can execute various calls on OMG.State, one happy path only", %{alice: alice} do
-    fee = %{@eth => [1]}
-
-    # deposits, transactions, utxo existence
-    assert {:ok, _} = State.deposit([%{owner: alice.addr, currency: @eth, amount: 10, blknum: 1}])
-    assert true == State.utxo_exists?(Utxo.position(1, 0, 0))
-
-    assert {:ok, _} = State.exec(TestHelper.create_recovered([{1, 0, 0, alice}], @eth, [{alice, 9}]), fee)
-
-    # block forming & status
-    assert {blknum, _} = State.get_status()
-    assert :ok = State.form_block()
-    # exits, with invalid ones
-    assert {:ok, _db, _} = State.exit_utxos([Utxo.position(blknum, 0, 0)])
-    # close block
-    assert {:ok, _db} = State.close_block()
-  end
 end

--- a/apps/omg/test/omg/state_test.exs
+++ b/apps/omg/test/omg/state_test.exs
@@ -18,16 +18,12 @@ defmodule OMG.StateTest do
   """
   use ExUnitFixtures
   use ExUnit.Case, async: false
-
   use OMG.DB.Fixtures
 
-  alias OMG.State
-  alias OMG.TestHelper
   alias OMG.Utxo
 
   require Utxo
 
-  @eth OMG.Eth.zero_address()
   @fee_claimer_address Base.decode16!("DEAD000000000000000000000000000000000000")
 
   deffixture standalone_state_server(db_initialized) do

--- a/apps/omg/test/support/integration/deposit_helper.ex
+++ b/apps/omg/test/support/integration/deposit_helper.ex
@@ -41,7 +41,7 @@ defmodule Support.Integration.DepositHelper do
   def deposit_to_child_chain(to, value, token_addr) when is_binary(token_addr) and byte_size(token_addr) == 20 do
     contract_addr = Encoding.from_hex(Configuration.contracts().erc20_vault)
 
-    {:ok, _} = Eth.Token.approve(to, contract_addr, value, token_addr) |> DevHelper.transact_sync!()
+    {:ok, _} = DevHelper.transact_sync!(Eth.Token.approve(to, contract_addr, value, token_addr))
 
     {:ok, receipt} =
       Transaction.Payment.new([], [{to, token_addr, value}])

--- a/apps/omg/test/support/test_helper.ex
+++ b/apps/omg/test/support/test_helper.ex
@@ -100,15 +100,18 @@ defmodule OMG.TestHelper do
   end
 
   def create_encoded_fee_tx(blknum, owner, currency, amount) do
-    %Transaction.Signed{
+    signed_transaction = %Transaction.Signed{
       raw_tx: Transaction.Fee.new(blknum, {owner, currency, amount}),
       sigs: []
     }
-    |> Transaction.Signed.encode()
+
+    Transaction.Signed.encode(signed_transaction)
   end
 
-  def create_recovered_fee_tx(blknum, owner, currency, amount),
-    do: create_encoded_fee_tx(blknum, owner, currency, amount) |> Transaction.Recovered.recover_from!()
+  def create_recovered_fee_tx(blknum, owner, currency, amount) do
+    encoded_fee_tx = create_encoded_fee_tx(blknum, owner, currency, amount)
+    Transaction.Recovered.recover_from!(encoded_fee_tx)
+  end
 
   @doc """
   convenience function around Transaction.new to create signed transactions (see create_recovered)
@@ -138,8 +141,8 @@ defmodule OMG.TestHelper do
   def create_signed(inputs, outputs) do
     raw_tx =
       Transaction.Payment.new(
-        inputs |> Enum.map(fn {blknum, txindex, oindex, _} -> {blknum, txindex, oindex} end),
-        outputs |> Enum.map(fn {owner, currency, amount} -> {owner.addr, currency, amount} end)
+        Enum.map(inputs, fn {blknum, txindex, oindex, _} -> {blknum, txindex, oindex} end),
+        Enum.map(outputs, fn {owner, currency, amount} -> {owner.addr, currency, amount} end)
       )
 
     privs = get_private_keys(inputs)
@@ -198,6 +201,5 @@ defmodule OMG.TestHelper do
     |> Map.new()
   end
 
-  defp get_private_keys(inputs),
-    do: Enum.map(inputs, fn {_, _, _, owner} -> owner.priv end)
+  defp get_private_keys(inputs), do: Enum.map(inputs, fn {_, _, _, owner} -> owner.priv end)
 end

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
@@ -486,8 +486,8 @@ defmodule OMG.ChildChain.BlockQueue.Core do
   defp next_blknum_to_mine(%{mined_child_block_num: mined, child_block_interval: interval}), do: mined + interval
 
   @spec to_mined_block_filter(Core.t()) :: ({pos_integer, BlockSubmission.t()} -> boolean)
-  defp to_mined_block_filter(%{formed_child_block_num: formed} = state) do
-    fn {blknum, _} -> next_blknum_to_mine(state) <= blknum and blknum <= formed end
+  defp to_mined_block_filter(state) do
+    fn {blknum, _} -> next_blknum_to_mine(state) <= blknum and blknum <= state.formed_child_block_num end
   end
 
   @spec should_form_block?(Core.t(), boolean()) :: boolean()

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
@@ -567,6 +567,7 @@ defmodule OMG.ChildChain.BlockQueue.Core do
       {mined_blocks, fresh_blocks} = split_existing_blocks(state, hashes)
 
       mined_submissions =
+        blocks =
         for {num, hash} <- mined_blocks do
           {num,
            %BlockSubmission{
@@ -575,7 +576,8 @@ defmodule OMG.ChildChain.BlockQueue.Core do
              nonce: calc_nonce(num, state.child_block_interval)
            }}
         end
-        |> Map.new()
+
+      Map.new(blocks)
 
       state = %{
         state
@@ -593,7 +595,8 @@ defmodule OMG.ChildChain.BlockQueue.Core do
   # mined are zipped with their numbers to submit
   defp split_existing_blocks(%__MODULE__{mined_child_block_num: blknum}, blknums_and_hashes) do
     {mined, fresh} =
-      Enum.find_index(blknums_and_hashes, &(elem(&1, 0) == blknum))
+      blknums_and_hashes
+      |> Enum.find_index(&(elem(&1, 0) == blknum))
       |> case do
         nil -> {[], blknums_and_hashes}
         index -> Enum.split(blknums_and_hashes, index + 1)

--- a/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/block_queue/core.ex
@@ -338,19 +338,6 @@ defmodule OMG.ChildChain.BlockQueue.Core do
     process_nonce_too_low(submission, newest_mined_blknum)
   end
 
-  # ganache has this error, but these are valid nonce_too_low errors, that just don't make any sense
-  # `process_nonce_too_low/2` would mark it as a genuine failure and crash the BlockQueue :(
-  # however, everything seems to just work regardless, things get retried and mined eventually
-  # NOTE: we decide to degrade the severity to warn and continue, considering it's just `ganache`
-  def process_submit_result(
-        _submission,
-        {:error, %{"code" => -32_000, "data" => %{"stack" => "n: the tx doesn't have the correct nonce" <> _}}} = error,
-        _newest_mined_blknum
-      ) do
-    log_ganache_nonce_too_low(error)
-    :ok
-  end
-
   # Fallback for unknown server errors: https://eth.wiki/json-rpc/json-rpc-error-codes-improvement-proposal
   # Only server errors are handled as they are the only set of errors that we have no control of.
   # Returns `:ok` so that BlockQueue can continue and do a retry, similar to a low replacement price error.
@@ -465,20 +452,14 @@ defmodule OMG.ChildChain.BlockQueue.Core do
 
   # Updates the state with information about last parent height and mined child block number
   @spec update_last_checked_mined_block_num(Core.t()) :: Core.t()
-  defp update_last_checked_mined_block_num(
-         %Core{
-           parent_height: parent_height,
-           mined_child_block_num: mined_child_block_num,
-           gas_price_adj_params: %GasPriceAdjustment{
-             last_block_mined: {_lastechecked_parent_height, lastchecked_mined_block_num}
-           }
-         } = state
-       ) do
-    if lastchecked_mined_block_num < mined_child_block_num do
+  defp update_last_checked_mined_block_num(state) do
+    {_, lastchecked_mined_block_num} = state.gas_price_adj_params.last_block_mined
+
+    if lastchecked_mined_block_num < state.mined_child_block_num do
       %Core{
         state
         | gas_price_adj_params:
-            GasPriceAdjustment.with(state.gas_price_adj_params, parent_height, mined_child_block_num)
+            GasPriceAdjustment.with(state.gas_price_adj_params, state.parent_height, state.mined_child_block_num)
       }
     else
       state
@@ -505,31 +486,24 @@ defmodule OMG.ChildChain.BlockQueue.Core do
   defp next_blknum_to_mine(%{mined_child_block_num: mined, child_block_interval: interval}), do: mined + interval
 
   @spec to_mined_block_filter(Core.t()) :: ({pos_integer, BlockSubmission.t()} -> boolean)
-  defp to_mined_block_filter(%{formed_child_block_num: formed} = state),
-    do: fn {blknum, _} -> next_blknum_to_mine(state) <= blknum and blknum <= formed end
+  defp to_mined_block_filter(%{formed_child_block_num: formed} = state) do
+    fn {blknum, _} -> next_blknum_to_mine(state) <= blknum and blknum <= formed end
+  end
 
   @spec should_form_block?(Core.t(), boolean()) :: boolean()
-  defp should_form_block?(
-         %Core{
-           parent_height: parent_height,
-           last_enqueued_block_at_height: last_enqueued_block_at_height,
-           block_submit_every_nth: block_submit_every_nth,
-           wait_for_enqueue: wait_for_enqueue
-         },
-         is_empty_block
-       ) do
+  defp should_form_block?(state, is_empty_block) do
     # e.g. if we're at 15th Ethereum block now, last enqueued was at 14th, we're submitting a child chain block on every
     # single Ethereum block (`block_submit_every_nth` == 1), then we could form a new block (`it_is_time` is `true`)
-    it_is_time = parent_height - last_enqueued_block_at_height >= block_submit_every_nth
-    should_form_block = it_is_time and !wait_for_enqueue and !is_empty_block
+    it_is_time = state.parent_height - state.last_enqueued_block_at_height >= state.block_submit_every_nth
+    should_form_block = it_is_time and !state.wait_for_enqueue and !is_empty_block
 
     _ =
       if !should_form_block do
         log_data = %{
-          parent_height: parent_height,
-          last_enqueued_block_at_height: last_enqueued_block_at_height,
-          block_submit_every_nth: block_submit_every_nth,
-          wait_for_enqueue: wait_for_enqueue,
+          parent_height: state.parent_height,
+          last_enqueued_block_at_height: state.last_enqueued_block_at_height,
+          block_submit_every_nth: state.block_submit_every_nth,
+          wait_for_enqueue: state.wait_for_enqueue,
           it_is_time: it_is_time,
           is_empty_block: is_empty_block
         }
@@ -566,8 +540,7 @@ defmodule OMG.ChildChain.BlockQueue.Core do
     with :ok <- block_number_and_hash_valid?(top_mined_hash, state.mined_child_block_num, hashes) do
       {mined_blocks, fresh_blocks} = split_existing_blocks(state, hashes)
 
-      mined_submissions =
-        blocks =
+      blocks =
         for {num, hash} <- mined_blocks do
           {num,
            %BlockSubmission{
@@ -577,7 +550,7 @@ defmodule OMG.ChildChain.BlockQueue.Core do
            }}
         end
 
-      Map.new(blocks)
+      mined_submissions = Map.new(blocks)
 
       state = %{
         state
@@ -593,10 +566,10 @@ defmodule OMG.ChildChain.BlockQueue.Core do
 
   # splits into ones that are before top_mined_hash and those after
   # mined are zipped with their numbers to submit
-  defp split_existing_blocks(%__MODULE__{mined_child_block_num: blknum}, blknums_and_hashes) do
+  defp split_existing_blocks(state, blknums_and_hashes) do
     {mined, fresh} =
       blknums_and_hashes
-      |> Enum.find_index(&(elem(&1, 0) == blknum))
+      |> Enum.find_index(&(elem(&1, 0) == state.mined_child_block_num))
       |> case do
         nil -> {[], blknums_and_hashes}
         index -> Enum.split(blknums_and_hashes, index + 1)
@@ -621,13 +594,6 @@ defmodule OMG.ChildChain.BlockQueue.Core do
   defp validate_block_hash(expected, {_blknum, blkhash}) when expected == blkhash, do: :ok
   defp validate_block_hash(_, nil), do: {:error, :mined_blknum_not_found_in_db}
   defp validate_block_hash(_, _), do: {:error, :hashes_dont_match}
-
-  defp log_ganache_nonce_too_low(error) do
-    # runtime sanity check if we're actually running `ganache`, if we aren't and we're here, we must crash
-    :ganache = Application.fetch_env!(:omg_eth, :eth_node)
-    _ = Logger.warn(inspect(error))
-    :ok
-  end
 
   defp log_success(submission, txhash) do
     _ = Logger.info("Submitted #{inspect(submission)} at: #{inspect(txhash)}")
@@ -666,7 +632,9 @@ defmodule OMG.ChildChain.BlockQueue.Core do
   end
 
   defp prepare_diagnostic(submission, newest_mined_blknum) do
-    config = Application.get_all_env(:omg_eth) |> Keyword.take([:contract_addr, :authority_address, :txhash_contract])
+    config =
+      :omg_eth |> Application.get_all_env() |> Keyword.take([:contract_addr, :authority_address, :txhash_contract])
+
     %{submission: submission, newest_mined_blknum: newest_mined_blknum, config: config}
   end
 end

--- a/apps/omg_child_chain/lib/omg_child_chain/ethereum_event_aggregator.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/ethereum_event_aggregator.ex
@@ -14,7 +14,7 @@
 defmodule OMG.ChildChain.EthereumEventAggregator do
   @moduledoc """
   This process combines all plasma contract events we're interested in and does eth_getLogs + enriches them if needed
-  for all Ethereum Event Listener processes. 
+  for all Ethereum Event Listener processes.
   """
   use GenServer
   require Logger
@@ -74,7 +74,7 @@ defmodule OMG.ChildChain.EthereumEventAggregator do
     {:ok,
      %{
        # 200 blocks of events will be kept in memory
-       delete_events_threshold_height_blknum: 200,
+       delete_events_threshold_height_blknum: 1000,
        ets_bucket: ets_bucket,
        event_signatures: events_signatures,
        events: events,

--- a/apps/omg_child_chain/lib/omg_child_chain/ethereum_event_aggregator.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/ethereum_event_aggregator.ex
@@ -74,7 +74,7 @@ defmodule OMG.ChildChain.EthereumEventAggregator do
     {:ok,
      %{
        # 200 blocks of events will be kept in memory
-       delete_events_threshold_height_blknum: 1000,
+       delete_events_threshold_ethereum_block_height: 1000,
        ets_bucket: ets_bucket,
        event_signatures: events_signatures,
        events: events,
@@ -213,8 +213,10 @@ defmodule OMG.ChildChain.EthereumEventAggregator do
     # block_number <= new_height - delete_events_threshold -> true end)
     match_spec = [
       {{:"$1", :"$2", :"$3"},
-       [{:"=<", :"$1", {:-, {:const, new_height_blknum}, {:const, state.delete_events_threshold_height_blknum}}}],
-       [true]}
+       [
+         {:"=<", :"$1",
+          {:-, {:const, new_height_blknum}, {:const, state.delete_events_threshold_ethereum_block_height}}}
+       ], [true]}
     ]
 
     :ets.select_delete(state.ets_bucket, match_spec)

--- a/apps/omg_child_chain/lib/omg_child_chain/supervisor.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/supervisor.ex
@@ -58,7 +58,7 @@ defmodule OMG.ChildChain.Supervisor do
          metrics_collection_interval: metrics_collection_interval
        ]},
       {BlocksCache, [ets: blocks_cache()]},
-      #  {FeeServer, fee_server_opts},
+      {FeeServer, fee_server_opts},
       {Monitor,
        [
          Alarm,

--- a/apps/omg_child_chain/lib/omg_child_chain/supervisor.ex
+++ b/apps/omg_child_chain/lib/omg_child_chain/supervisor.ex
@@ -58,7 +58,7 @@ defmodule OMG.ChildChain.Supervisor do
          metrics_collection_interval: metrics_collection_interval
        ]},
       {BlocksCache, [ets: blocks_cache()]},
-      {FeeServer, fee_server_opts},
+      #  {FeeServer, fee_server_opts},
       {Monitor,
        [
          Alarm,

--- a/apps/omg_child_chain/test/omg_child_chain/block_queue/core_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/block_queue/core_test.exs
@@ -265,9 +265,7 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
                |> Core.enqueue_block("1", 1000, 0)
                |> Core.set_ethereum_status(4, 0, false)
 
-      assert {:dont_form_block, queue} =
-               queue
-               |> Core.set_ethereum_status(5, 0, false)
+      assert {:dont_form_block, queue} = Core.set_ethereum_status(queue, 5, 0, false)
 
       assert {:do_form_block, _queue} =
                queue
@@ -304,17 +302,11 @@ defmodule OMG.ChildChain.BlockQueue.CoreTest do
     test "Block generation is driven by last enqueued block Ethereum height and if block is empty or not", %{
       empty: empty
     } do
-      assert {:dont_form_block, _} =
-               empty
-               |> Core.set_ethereum_status(0, 0, false)
+      assert {:dont_form_block, _} = Core.set_ethereum_status(empty, 0, 0, false)
 
-      assert {:dont_form_block, _} =
-               empty
-               |> Core.set_ethereum_status(1, 0, true)
+      assert {:dont_form_block, _} = Core.set_ethereum_status(empty, 1, 0, true)
 
-      assert {:do_form_block, queue} =
-               empty
-               |> Core.set_ethereum_status(1, 0, false)
+      assert {:do_form_block, queue} = Core.set_ethereum_status(empty, 1, 0, false)
 
       assert {:dont_form_block, _} =
                queue

--- a/apps/omg_child_chain/test/omg_child_chain/ethereum_event_aggregator_test.exs
+++ b/apps/omg_child_chain/test/omg_child_chain/ethereum_event_aggregator_test.exs
@@ -107,7 +107,7 @@ defmodule OMG.ChildChain.EthereumEventAggregatorTest do
   describe "delete_old_logs/2" do
     # we start the test with a completely empty ETS table, meaning to events were retrieved yet
     # so the first call from a ETH event listener would actually retrieve values from Infura
-    test "that :delete_events_threshold_height_blknum is respected and that events get deleted from ETS", %{
+    test "that :delete_events_threshold_ethereum_block_height is respected and that events get deleted from ETS", %{
       event_fetcher_name: event_fetcher_name,
       table: table,
       test: test_name
@@ -133,7 +133,11 @@ defmodule OMG.ChildChain.EthereumEventAggregatorTest do
       from_block = 1
       to_block = 3
       :sys.replace_state(event_fetcher_name, fn state -> Map.put(state, :rpc, test_name) end)
-      :sys.replace_state(event_fetcher_name, fn state -> Map.put(state, :delete_events_threshold_height_blknum, 1) end)
+
+      :sys.replace_state(event_fetcher_name, fn state ->
+        Map.put(state, :delete_events_threshold_ethereum_block_height, 1)
+      end)
+
       events = event_fetcher_name |> :sys.get_state() |> Map.get(:events)
 
       # create data that we need

--- a/apps/omg_eth/test/support/dev_geth.ex
+++ b/apps/omg_eth/test/support/dev_geth.ex
@@ -103,7 +103,7 @@ defmodule OMG.Eth.DevGeth do
 
     waiting_task
     |> Task.async()
-    |> Task.await(15_000)
+    |> Task.await(15_000 * 2)
 
     pid
   end

--- a/apps/omg_utils/lib/omg_utils/http_rpc/validators/base.ex
+++ b/apps/omg_utils/lib/omg_utils/http_rpc/validators/base.ex
@@ -58,7 +58,7 @@ defmodule OMG.Utils.HttpRPC.Validator.Base do
     opts
     |> replace_aliases()
     |> Enum.reduce(
-      map |> get(key),
+      get(map, key),
       &validate/2
     )
     |> case do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,8 @@ services:
     environment:
       RPC_PORT: 8545
     ports:
-      - "8545:8545"
-      - "8546:8546"
+      - "8555:8545"
+      - "8556:8546"
     expose:
       - "8545"
       - "8546"
@@ -38,6 +38,8 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    depends_on:
+      - nginx
     networks:
       chain_net:
         ipv4_address: 172.27.0.101

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,42 +20,19 @@ services:
 
   geth:
     image: ethereum/client-go:v1.9.12
-    entrypoint:
-      - /bin/sh
-      - -c
-      - |
-          apk add --update curl
-          # Configures geth with the deployer and authority accounts. This includes:
-          #   1. Configuring the deployer's keystore
-          #   2. Configuring the authority's keystore
-          #   3. Configuring the keystores' password
-          #   4. Unlocking the accounts by their indexes
-          # CAREFUL with --allow-insecure-unlock!
-          echo "" > /tmp/geth-blank-password
-          # Starts geth
-          # Websocket is not used by the applications but enabled for debugging/testing convenience
-          geth --miner.gastarget 7500000 \
-            --miner.gasprice "10" \
-            --nodiscover \
-            --maxpeers 0 \
-            --datadir data/ \
-            --syncmode 'full' \
-            --networkid 1337 \
-            --keystore=./data/geth/keystore/ \
-            --password /tmp/geth-blank-password \
-            --unlock "0,1" \
-            --rpc --rpcapi personal,web3,eth,net --rpcaddr 0.0.0.0 --rpcvhosts=* --rpcport=8545 \
-            --ws --wsaddr 0.0.0.0 --wsorigins='*' \
-            --mine \
-            --allow-insecure-unlock
+    entrypoint: /bin/sh -c ". data/command"
+    environment:
+      RPC_PORT: 8545
     ports:
-      - "8555:8545"
-      - "8556:8546"
+      - "8545:8545"
+      - "8546:8546"
     expose:
-      - "8546"
       - "8545"
+      - "8546"
     volumes:
       - ./data:/data
+      - ./docker/geth/command:/data/command
+      - ./docker/geth/geth-blank-password:/data/geth-blank-password
     healthcheck:
       test: curl localhost:8545
       interval: 5s

--- a/docker/geth/command
+++ b/docker/geth/command
@@ -1,0 +1,31 @@
+# Configures geth with the deployer and authority accounts. This includes:
+#   1. Configuring the deployer's keystore
+#   2. Configuring the authority's keystore
+#   3. Configuring the keystores' password
+#   4. Unlocking the accounts by their indexes
+# CAREFUL with --allow-insecure-unlock!
+# Starts geth
+# Websocket is not used by the applications but enabled for debugging/testing convenience
+geth \
+--miner.gastarget 7500000 \
+--nousb \
+--miner.gasprice "10" \
+--nodiscover \
+--maxpeers 0 \
+--datadir data/ \
+--syncmode 'fast' \
+--networkid 1337 \
+--gasprice '1' \
+--keystore ./data/geth/keystore/ \
+--password /data/geth-blank-password \
+--unlock "0,1" \
+--rpc \
+--rpcapi personal,web3,eth,net  \
+--rpcaddr 0.0.0.0  \
+--rpcvhosts=* \
+--rpcport=${RPC_PORT} \
+--ws  \
+--wsaddr 0.0.0.0  \
+--wsorigins='*' \
+--mine \
+--allow-insecure-unlock


### PR DESCRIPTION
https://github.com/omgnetwork/elixir-omg/issues/1624

## Overview

ETH listeners had their own in memory cache which is not needed anymore with the introduction of ETH aggregator.

## Changes

Describe your changes and implementation choices. More details make PRs easier to review.

- Simplfy Core logic, remove cache.

## Testing

Same stuff, will monitor RPC calls when on development via datadog